### PR TITLE
Update board ID for Adafruit Feather M0

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -7,7 +7,7 @@
 ; Please visit documentation for the other options and examples
 ; http://docs.platformio.org/en/stable/projectconf.html
 [platformio]
-# env_default = adafruit_feather_m0_usb
+# env_default = adafruit_feather_m0
 src_dir = examples/printData
 #lib_dir = lib
 
@@ -41,10 +41,10 @@ board = zeroUSB
 # lib_deps =  ${common_samd.lib_deps}
 # lib_ignore = ${common_samd.lib_ignore}
 
-[env:adafruit_feather_m0_usb]
+[env:adafruit_feather_m0]
 platform = atmelsam
 framework = arduino
-board = adafruit_feather_m0_usb
+board = adafruit_feather_m0
 # lib_deps =  ${common_samd.lib_deps}
 # lib_ignore = ${common_samd.lib_ignore}
 


### PR DESCRIPTION
Platformio changed the board ID from `adafruit_feather_m0_usb` to `adafruit_feather_m0`:
https://github.com/platformio/platform-atmelsam/commit/777168add0580934204a0b081533b652bc35088b